### PR TITLE
Fix missing redis password in showtime.php

### DIFF
--- a/Campaign/public/showtime.php
+++ b/Campaign/public/showtime.php
@@ -290,6 +290,8 @@ $redis = new \Predis\Client([
     'scheme' => 'tcp',
     'host'   => getenv('REDIS_HOST'),
     'port'   => getenv('REDIS_PORT') ?: 6379,
+],[
+    'parameters' => ['password' => env('REDIS_PASSWORD', null)],
 ]);
 
 /** @var \App\Contracts\SegmentAggregator $segmentAggregator */

--- a/Campaign/public/showtime.php
+++ b/Campaign/public/showtime.php
@@ -290,10 +290,8 @@ $redis = new \Predis\Client([
     'scheme' => 'tcp',
     'host'   => getenv('REDIS_HOST'),
     'port'   => getenv('REDIS_PORT') ?: 6379,
-],[
-    'parameters' => ['password' => env('REDIS_PASSWORD', null)],
+    'password' => getenv('REDIS_PASSWORD') ?: null,
 ]);
-
 /** @var \App\Contracts\SegmentAggregator $segmentAggregator */
 $segmentAggregator = unserialize($redis->get(\App\Providers\AppServiceProvider::SEGMENT_AGGREGATOR_REDIS_KEY))();
 if (!$segmentAggregator) {


### PR DESCRIPTION
In case that you set in .env password for redis, it is not used in showtime.php