### PR TITLE
solve CORB for incorrect mime type

### DIFF
--- a/Campaign/public/showtime.php
+++ b/Campaign/public/showtime.php
@@ -10,7 +10,7 @@ use Monolog\Logger;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-header('Content-Type: application/json');
+header('Content-Type: application/javascript');
 
 $dotenv = new \Dotenv\Dotenv(__DIR__ . '/../');
 $dotenv->load();


### PR DESCRIPTION
If CORB is enabled via `X-Content-Type-Options: nosniff` then it is not allowed to insert application/json into <script> tag. Fixed by using allowed mime-type.