### PR TITLE
Wrong step description into trackPaymentWithSource

### DIFF
--- a/Beam/resources/assets/js/remplib.js
+++ b/Beam/resources/assets/js/remplib.js
@@ -429,7 +429,7 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
 
         trackPaymentWithSource: function(transactionId, amount, currency, productIds, article, source) {
             let params = {
-                "step": "purchase",
+                "step": "payment",
                 "article": article,
                 "purchase": {
                     "transaction_id": transactionId,


### PR DESCRIPTION
trackPaymentWithSource was defining it's step as "purchase" and not as payment, as it is expected.