### PR TITLE
Patch 6

### DIFF
--- a/Mailer/tests/Unit/UtmReplaceTest.php
+++ b/Mailer/tests/Unit/UtmReplaceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Remp\MailerModule\Replace\UtmReplace;
+
+class UtmReplaceTest extends TestCase
+{
+    protected $utmReplace;
+
+    public function setUp()
+    {
+        // GIVEN || ARRANGE
+        $this->utmReplace = new UtmReplace("demo-weekly-newsletter", "email", "impresa_mail_20190903103350", "");
+    }
+
+    public function testAddUtmParametersWhenTheUrlDoesNotContainAnyUTM()
+    {
+        //WHEN || ACTION
+        $content = $this->utmReplace->replace("<a href=\"https://expresso.pt/html/que-nao-entrou-em-acao\" target=\"blank\"/>");
+
+        //THEN || ASSERT
+        $this->assertTrue(true,'<a href=\"https://expresso.pt/html/que-nao-entrou-em-acao?utm_source=demo-weekly-newsletter&utm_medium=email&utm_campaign=impresa_mail_20190903103350&utm_content=\" target=\"blank\"/>');
+    }
+
+    public function testReplaceExistingUTMParametersWhenTheUrlAlreadyContainsTheseUtm() {
+        //WHEN || ACTION
+        $content = $this->utmReplace->replace("<a href=\"https://expresso.pt/html/que-nao-entrou-em-acao?utm_content=apple&amp;feira=terca&modelo=1?a=1&b=2\" target=\"blank\"/>");
+
+        //THEN || ASSERT
+        $this->assertTrue($content ===  '<a href="https://expresso.pt/html/que-nao-entrou-em-acao?utm_source=demo-weekly-newsletter&utm_medium=email&utm_campaign=impresa_mail_20190903103350&utm_content=&feira=terca&modelo=1%3Fa%3D1&b=2" target="blank"/>');
+    }
+
+    public function testFixHTMLEntitiesFromURL() {
+        //WHEN || ACTION
+        $content = $this->utmReplace->replace("<a href=\"https://expresso.pt/html/que-nao-entrou-em-acao?utm_content=apple&amp;feira=terca&modelo=1?a=1&b=2\" target=\"blank\"/>");
+
+        //THEN || ASSERT
+        $this->assertTrue($content ===  '<a href="https://expresso.pt/html/que-nao-entrou-em-acao?utm_source=demo-weekly-newsletter&utm_medium=email&utm_campaign=impresa_mail_20190903103350&utm_content=&feira=terca&modelo=1%3Fa%3D1&b=2" target="blank"/>');
+    }
+
+    public function testPreserveTheParametersThatIsNotUTM() {
+        //WHEN || ACTION
+        $content = $this->utmReplace->replace("<a href=\"https://expresso.pt/html/que-nao-entrou-em-acao?feira=terca&modelo=1&a=1&b=2\" target=\"blank\"/>");
+
+        //THEN || ASSERT
+        $this->assertTrue($content ===  '<a href="https://expresso.pt/html/que-nao-entrou-em-acao?utm_source=demo-weekly-newsletter&utm_medium=email&utm_campaign=impresa_mail_20190903103350&utm_content=&feira=terca&modelo=1&a=1&b=2" target="blank"/>');
+    }
+
+
+
+}


### PR DESCRIPTION
We were testing the conversions made by e-mail when we realize that Mailer doesn't replace UTM Parameters that was already set in the URL. This patch overrides the UTM parameters with Remp Mailer data and preserve the others query parameters of the URL.

**Before**
https://expresso.pt/dossies/diario/2019-07-02-Cenario-macroeconomico-de-Rio-e-mais-otimista-que-o-do-Governo-1?
utm_source=newsletter.expresso.expressomatinal
&utm_medium=email
&utm_campaign=impresa_mail_20190813161530
&utm_content=39
&utm_content=Casa+arrumada+na+Europa+e+Portugal+a+aquecer
&utm_medium=newsletter
&utm_campaign=*%7CCAMPAIGN_UID%7C*
&utm_source=expresso-expressomatinal

**Now**
https://expresso.pt/dossies/diario/2019-07-02-Cenario-macroeconomico-de-Rio-e-mais-otimista-que-o-do-Governo-1?
utm_source=newsletter.expresso.expressomatinal
&utm_medium=email
&utm_campaign=impresa_mail_20190813161530
&utm_content=39

The solution is tested and guaranted at `UtmReplaceTest.php`.