### PR TITLE
Added setUp function in ScheduleTest

### DIFF
--- a/Campaign/tests/Unit/ScheduleTest.php
+++ b/Campaign/tests/Unit/ScheduleTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class ScheduleTest extends TestCase
 {
+    protected function setUp() {}
+	
     public function testWaitingSchedule()
     {
         $schedule = new Schedule([


### PR DESCRIPTION
When running Unit Tests from Campaign Manager, I got 9 errors which throws the following message: Predis\Connection\ConnectionException: Connection refused [tcp://redis:6379]. The problem was solved overriding the setUp method from TestCase.

Before:
![Screenshot from 2019-09-17 21-21-10](https://user-images.githubusercontent.com/2372140/65076529-19550b80-d991-11e9-95c1-1d6c165b9a8e.png)

After:
![Screenshot from 2019-09-17 21-21-46](https://user-images.githubusercontent.com/2372140/65076569-2eca3580-d991-11e9-9e23-1eea025391bb.png)
