### PR TITLE
Custom JS was not being triggered

### DIFF
--- a/Campaign/resources/assets/js/components/BannerPreview.vue
+++ b/Campaign/resources/assets/js/components/BannerPreview.vue
@@ -267,27 +267,11 @@
                 }
             }
 
-            let vm = this,
-                js = this.js,
-                loadedScriptsCount = 0;
-
-            if (this.jsIncludes) {
-                for (let ii = 0; ii < this.jsIncludes.length; ii++) {
-                    if (!this.jsIncludes[ii]) {
-                        loadedScriptsCount++;
-                        continue;
-                    }
-
-                    lib.loadScript(this.jsIncludes[ii], function () {
-                        loadedScriptsCount++;
-                        if (loadedScriptsCount === vm.jsIncludes.length) {
-                            vm.runCustomJavascript(js);
-                        }
-                    });
-                }
-            } else {
-                this.runCustomJavascript(js);
-            }
+            this.jsIncludes && this.jsIncludes
+                .filter(jsInclude => jsInclude)
+                .forEach((jsInclude) => lib.loadScript(jsInclude));
+            
+            this.runCustomJavascript(this.js);
         },
         data: () => ({
             visible: false,


### PR DESCRIPTION
Custom JS of the Banner was not being triggered. 

Scenario:
1. There was a custom js (you can test with an alert);
2. There was no js include;

In this scenario, the variable this.jsIncludes, for some reason, represents an array of one position with null value. So the condition on line 276 results true, executing the continue statement. As there was only one null position on array, the code above line 281 was never executed because the for didn't have any more elements to execute.

The bug can be easily reproduced adding an alert inside the custom js of a banner. 

I corrected the bug and simplified the algorithm. Hope you enjoy the art.