### PR TITLE
BugFix: LeftMenu/Conversions/conversions were not showing articles wi…

### DIFF
--- a/Beam/app/Http/Controllers/ConversionController.php
+++ b/Beam/app/Http/Controllers/ConversionController.php
@@ -37,8 +37,8 @@ class ConversionController extends Controller
         $conversions = Conversion::select('conversions.*')
             ->with(['article', 'article.authors', 'article.sections'])
             ->join('articles', 'articles.id', '=', 'conversions.article_id')
-            ->join('article_author', 'articles.id', '=', 'article_author.article_id')
-            ->join('article_section', 'articles.id', '=', 'article_section.article_id');
+            ->leftJoin('article_author', 'articles.id', '=', 'article_author.article_id')
+            ->leftJoin('article_section', 'articles.id', '=', 'article_section.article_id');
 
 
         if ($request->input('conversion_from')) {


### PR DESCRIPTION
The LeftMenu --> Conversions --> conversions were not showing articles that were created via REST API with empty authors.

**Replicate the problem:**
1- Create an article without authors via Rest API
2- Create a subscription for that article
3- Check that the article is not showing as expected