### PR TITLE
Bug Correction

### DIFF
--- a/Campaign/app/Campaign.php
+++ b/Campaign/app/Campaign.php
@@ -252,8 +252,8 @@ class Campaign extends Model
             ->pluck('campaign_id')
             ->unique()
             ->toArray();
-
-        Redis::set(self::ACTIVE_CAMPAIGN_IDS, Json::encode($activeCampaignIds));
+        
+        Redis::set(self::ACTIVE_CAMPAIGN_IDS, Json::encode(array_values($activeCampaignIds)));
 
         return collect($activeCampaignIds);
     }


### PR DESCRIPTION
**Problem**
At release 0.9.1, an Internal Server Error occurs during banner rendering. All banners stopped working.

![image](https://user-images.githubusercontent.com/2372140/69552750-ee8dc180-0f96-11ea-989d-ed5d88b27466.png)

**Investigation**
The log was pointing to CampaignController and registering that campaignIds was not an array.
![image](https://user-images.githubusercontent.com/2372140/69552883-21d05080-0f97-11ea-84bf-4a7c1639af09.png)

The code in error was this one:
![image](https://user-images.githubusercontent.com/2372140/69552967-4298a600-0f97-11ea-945a-dbce53548d2e.png)

After going to Redis CLI and executing the same query, I got this result:
![image](https://user-images.githubusercontent.com/2372140/69553033-56440c80-0f97-11ea-913b-fc694a2dda5d.png)

In fact, it was not an array. It was a JavaScript object. Taking a better look at the value, I realized that the key '18' was missing. It was being removed from the array.
![image](https://user-images.githubusercontent.com/2372140/69553122-81c6f700-0f97-11ea-8c98-b6f721bb0145.png)

Inside Campaign.php, when querying all the running or planned Schedules, repeated values was being removed with the ->unique() function.
![image](https://user-images.githubusercontent.com/2372140/69553325-ed10c900-0f97-11ea-8af1-a6bdb69254d4.png)

I went to the Campaigns and discovered that one of them had two schedules.
![image](https://user-images.githubusercontent.com/2372140/69553503-33febe80-0f98-11ea-8491-63bba485c64c.png)

I went to the database to confirm if we had any repeated value inside Schedules table in Campaign database.
![image](https://user-images.githubusercontent.com/2372140/69553423-1b8ea400-0f98-11ea-97f3-9b328f2f5a08.png)

**Conclusion**
When we call ->unique(), this function removes repeated elements in the resulting array. When it happens, an array like` [0 => 1, 1 => 1, 2 => 2] ` turns into` [0 => 1, 2 => 2]`. The array is not continuous anymore. When we call Json::encode with an array that the keys are numeric and not continuous, it converts the value into an object and not in an array.

So this...
![image](https://user-images.githubusercontent.com/2372140/69553829-ae2f4300-0f98-11ea-94ca-423242b7ea46.png)

Is saved as this...
![image](https://user-images.githubusercontent.com/2372140/69553844-b7b8ab00-0f98-11ea-9f35-103a6a1fd74c.png)

**Solution**
Call array_values($campaignIds) to guarantee that the array keys are continuous. The value now is converted into an array like it is expected.