### PR TITLE
Bug in migrations 'attachment_size' wrong datetype

### DIFF
--- a/Mailer/migrations/20170829092344_mail_logs.php
+++ b/Mailer/migrations/20170829092344_mail_logs.php
@@ -18,7 +18,7 @@ class MailLogs extends AbstractMigration
             ->addColumn('hard_bounced_at', 'datetime', ['null' => true])
             ->addColumn('clicked_at', 'datetime', ['null' => true])
             ->addColumn('opened_at', 'datetime', ['null' => true])
-            ->addColumn('attachment_size', 'datetime', ['null' => true])
+            ->addColumn('attachment_size', 'integer', ['null' => true])
             ->addTimestamps()
 
             ->addForeignKey('mail_template_id', 'mail_templates', 'id', ['delete' => 'RESTRICT', 'update' => 'CASCADE'])


### PR DESCRIPTION
It should be integer, otherwise sometime email send will fail