### PR TITLE
[webpack][dx] - watchers compile also local package Package/remp automatically

### DIFF
--- a/Beam/webpack.mix.js
+++ b/Beam/webpack.mix.js
@@ -1,6 +1,9 @@
 let mix = require('laravel-mix').webpackConfig({
+    resolve: {
+        symlinks: false,
+    },
     watchOptions: {
-        ignored: /node_modules/,
+        ignored: [ /node_modules([\\]+|\/)+(?!remp)/ ]
     }
 }).version();
 

--- a/Campaign/webpack.mix.js
+++ b/Campaign/webpack.mix.js
@@ -1,6 +1,9 @@
 let mix = require('laravel-mix').webpackConfig({
+    resolve: {
+        symlinks: false,
+    },
     watchOptions: {
-        ignored: /node_modules/,
+        ignored: [ /node_modules([\\]+|\/)+(?!remp)/ ]
     }
 }).version();
 

--- a/Docker/php/remp.sh
+++ b/Docker/php/remp.sh
@@ -12,6 +12,9 @@ then
     yarn install --no-bin-links
     chmod -R u+x node_modules
 
+    yarn link --cwd ../Package/remp
+    yarn link remp
+
     npm run | grep "all-dev"
     if [ $? -eq "0" ]; then
         yarn run all-dev

--- a/Mailer/webpack.mix.js
+++ b/Mailer/webpack.mix.js
@@ -3,8 +3,11 @@ let publicPath = "www/assets/vendor/";
 
 mix
     .webpackConfig({
+        resolve: {
+            symlinks: false,
+        },
         watchOptions: {
-            ignored: /node_modules/,
+            ignored: [ /node_modules([\\]+|\/)+(?!remp)/ ]
         }
     })
     .options({

--- a/Package/remp/package.json
+++ b/Package/remp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "remp",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=8.6"
+  }
+}

--- a/Sso/webpack.mix.js
+++ b/Sso/webpack.mix.js
@@ -1,6 +1,9 @@
 let mix = require('laravel-mix').webpackConfig({
+    resolve: {
+        symlinks: false,
+    },
     watchOptions: {
-        ignored: /node_modules/,
+        ignored: [ /node_modules([\\]+|\/)+(?!remp)/ ]
     }
 }).version();
 


### PR DESCRIPTION
Changes to imporve Developer Experience (DX)
Compiling of resources from local package will now be done automatically when using `yarn run watch`
No need to copy/move files.

- local package Package/remp - linked using yarn link - inside remp.sh build process
- changed webpack.mix.js so it can correctly resolve path to linked package (still ignore node_modules, except for remp package)
- run `yarn run watch` in any of the main containers
- directly edit files in `Package/remp` eg. `Package/remp/js/functions.js` watch will catch and recompile your changes.