### PR TITLE
BugFix: Empty cookies / storage entries

### DIFF
--- a/Beam/resources/assets/js/remplib.js
+++ b/Beam/resources/assets/js/remplib.js
@@ -17,7 +17,7 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
         social: null,
 
         campaign_id: null,
-
+ 
         _: [],
 
         article: {
@@ -654,6 +654,9 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
 
         parseUriParams: function() {
             var query = window.location.search.substring(1);
+            
+            if (!query) return;
+            
             var vars = query.split('&');
 
             const now = new Date();


### PR DESCRIPTION
In Firefox (not tested in another browsers), the method parseUriParams was creating empty entries in Cookies / Local Storage when there's no query params.

![image](https://user-images.githubusercontent.com/2372140/89289157-ac04a480-d64e-11ea-980d-0a6f201e5903.png)

![image](https://user-images.githubusercontent.com/2372140/89289180-b45cdf80-d64e-11ea-8f8a-639a991373c1.png)

This is the scenario to reproduce the problem:
1. There's no uri param;
2. Function `window.location.search.substring(1)` returned empty `""` to variable named `query`;
3. Function `query.split('&')` was returning an array containg one `""` empty value;
4. The for iterator considered empty `""` as a value and `remplib.setStorage(key, item)` is called with `remplib.setStorage("", undefined)`;

![image](https://user-images.githubusercontent.com/2372140/89289248-ccccfa00-d64e-11ea-89ab-e606054db6ff.png)

Solution:
A conditional checking if variable query is empty or undefined that returns in case of true.