### PR TITLE
Support for custom fields in Pageviews

### DIFF
--- a/Beam/README.md
+++ b/Beam/README.md
@@ -1253,7 +1253,19 @@ var rempConfig = {
         
         // optional, allows to specify custom referer medium  
         // this value overrides implicit referer medium computed from Referer header by tracker 
-        refererMedium: "push_notification"
+        refererMedium: "push_notification",
+        
+        // optional, allows to add custom fields for pageview events
+        //
+        // Key represents variable name, value should be defined as callback returning string response.
+        // Following example will be persisted in ElasticSearch as "foo: bar" and "baz: XXX".
+        // If the value is not function, remplib validation will throw an error and won't proceed further.
+        pageviews: {
+            fields: {
+                foo: function() { return "bar" },
+                baz: function() { return "XXX" }
+            }       
+        } 
     },
 };
 remplib.tracker.init(rempConfig);

--- a/Beam/go/cmd/tracker/controller/track.go
+++ b/Beam/go/cmd/tracker/controller/track.go
@@ -233,6 +233,11 @@ func (c *TrackController) Pageview(ctx *app.PageviewTrackContext) error {
 	}
 
 	tags, fields = c.payloadToTagsFields(ctx.Payload.System, ctx.Payload.User, tags, fields)
+
+	for key, val := range ctx.Payload.Fields {
+		fields[key] = val
+	}
+
 	if err := c.pushInternal(measurement, ctx.Payload.System.Time, tags, fields); err != nil {
 		return err
 	}

--- a/Beam/go/cmd/tracker/design/user_types.go
+++ b/Beam/go/cmd/tracker/design/user_types.go
@@ -45,6 +45,7 @@ var Pageview = Type("Pageview", func() {
 	Attribute("article", Article)
 	Attribute("timespent", TimeSpent)
 	Attribute("progress", Progress)
+	Attribute("fields", HashOf(String, Any), "Additinal key-value data")
 
 	Required("system", "user", "action")
 })

--- a/Beam/resources/assets/js/remplib.js
+++ b/Beam/resources/assets/js/remplib.js
@@ -62,6 +62,8 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
 
         maxPageProgressAchieved: 0,
 
+        fields: {},
+
         initialized: false,
 
         init: function(config) {
@@ -190,6 +192,11 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
                         remplib.tracker.sendTrackedProgress(true)
                     });
                 }
+            }
+
+            if (typeof config.pageviews === 'object') {
+                this.validateFieldsCallback(config.pageviews.fields);
+                this.fields = config.pageviews.fields || {};
             }
 
             this.initialized = true;
@@ -367,6 +374,7 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
             var params = {
                 "article": this.article,
                 "action": "load",
+                "fields": this.processFields()
             };
             params = this.addSystemUserParams(params);
             this.post(this.url + "/track/pageview", params);
@@ -845,6 +853,24 @@ remplib = typeof(remplib) === 'undefined' ? {} : remplib;
             params = this.addSystemUserParams(params);
             remplib.tracker.post(this.url + "/track/pageview", params);
             remplib.tracker.trackedProgress = [];
+        },
+
+        validateFieldsCallback: function(fields) {
+            for (let param in fields) {
+                if (fields.hasOwnProperty(param) && typeof (fields[param]) !== "function") {
+                    throw "remplib: configuration pageviews.fields invalid (callback required) for param: " + param
+                }
+            }
+        },
+
+        processFields: function() {
+            let fields = {};
+
+            for (let key in this.fields) {
+                fields[key] = this.fields[key]();
+            }
+
+            return fields;
         }
     };
 


### PR DESCRIPTION
**Story**
So that I can be able to analyze Page Views with more details
As a data engineer 
I want to add custom data to Page Views events

**Description**
This pull request contains code that makes it possible to attach custom data (as user region) to a Page View event. To do so, user must define now a _pageview_ field inside Javascripot Beam configuration containing a property called fields. Fields must contain properties defined as callbacks.

Read docs for more details.