### PR TITLE
[Campaign] Fix duplicated routes

### DIFF
--- a/Campaign/routes/api.php
+++ b/Campaign/routes/api.php
@@ -20,16 +20,16 @@ use App\Http\Controllers\ScheduleController;
 
 Route::middleware('auth:api')->group(function() {
     Route::prefix('schedule')->group(function() {
-        Route::post('{schedule}/start', [ScheduleController::class, 'start'])->name('schedule.start');
-        Route::post('{schedule}/pause', [ScheduleController::class, 'pause'])->name('schedule.pause');
-        Route::post('{schedule}/stop', [ScheduleController::class, 'stop'])->name('schedule.stop');
+        Route::post('{schedule}/start', [ScheduleController::class, 'start'])->name('api.schedule.start');
+        Route::post('{schedule}/pause', [ScheduleController::class, 'pause'])->name('api.schedule.pause');
+        Route::post('{schedule}/stop', [ScheduleController::class, 'stop'])->name('api.schedule.stop');
     });
 
     Route::post('banners/{banner}/one-time-display', [BannerController::class, 'oneTimeDisplay'])->name('api.banners.one_time_display');
 
-    Route::apiResource('campaigns', CampaignController::class);
-    Route::apiResource('banners', BannerController::class);
-    Route::apiResource('schedule', ScheduleController::class);
+    Route::apiResource('api.campaigns', CampaignController::class);
+    Route::apiResource('api.banners', BannerController::class);
+    Route::apiResource('api.schedule', ScheduleController::class);
 
     Route::post('campaigns/toggle-active/{campaign}', [CampaignController::class, 'toggleActive'])->name('api.campaigns.toggle_active');
 


### PR DESCRIPTION
After running the command `php artisan route:cache` I got the error: 
`Unable to prepare route [schedule/{schedule}/start] for serialization. Another route has already been assigned name [schedule.start].`

Seems there is name conflict in route names. I have added prefix `api.` for api routes to fix the problem.