### PR TITLE
fix(Campaign): added check for undefined campaign.config in BannerPre…

### DIFF
--- a/Campaign/extensions/campaign-module/resources/assets/js/components/BannerPreview.vue
+++ b/Campaign/extensions/campaign-module/resources/assets/js/components/BannerPreview.vue
@@ -494,6 +494,9 @@
                 this.closeTracked = true;
             },
             clicked: function(event, hideBanner = false) {
+                if (typeof remplib.campaign === 'undefined') {
+                    return;
+                }
                 remplib.campaign.storeCampaignClicked(this.campaignPublicId);
 
                 if (this.manualEventsTracking || this.clickTracked) {


### PR DESCRIPTION
In the admin panel of the Campaign module, when editing or creating a banner, the transition to target_url did not occur, and an error occurred. This was due to the fact that campaign.config was not initialised in the admin panel. A "undefined" check has been added.